### PR TITLE
Use tlsconfig to configure server-side authentication.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20190916225859-5f1c360e9bc1 // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/runtimeschema v0.0.0-20180622184205-c38d8be9f68c
-	code.cloudfoundry.org/tlsconfig v0.0.0-20190710180242-462f72de1106
+	code.cloudfoundry.org/tlsconfig v0.0.0-20200108215323-551ec42d1f74
 	code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/go-test/deep v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ code.cloudfoundry.org/runtimeschema v0.0.0-20180622184205-c38d8be9f68c h1:SmIVuw
 code.cloudfoundry.org/runtimeschema v0.0.0-20180622184205-c38d8be9f68c/go.mod h1:QSfnsqiGUdV3OOxqHxQkmUZwycGJNWYdredPgeGuGf4=
 code.cloudfoundry.org/tlsconfig v0.0.0-20190710180242-462f72de1106 h1:F36x++Jh2aWiBK++W9wI97SJuprnROicHiV0HtdSOzc=
 code.cloudfoundry.org/tlsconfig v0.0.0-20190710180242-462f72de1106/go.mod h1:VxNwgI63VxUGfSR/F3VzjOpnWLbeH+AB1pQugK1i1bA=
+code.cloudfoundry.org/tlsconfig v0.0.0-20200108215323-551ec42d1f74 h1:aLin7Z4YfLFnvz6Tn1ABosJdEk4KZDTWIbVb81PYVg0=
+code.cloudfoundry.org/tlsconfig v0.0.0-20200108215323-551ec42d1f74/go.mod h1:eTbFJpyXRGuFVyg5+oaj9B2eIbIc+0/kZjH8ftbtdew=
 code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50 h1:y+DtLO/eX/9NZjGGHntWs1bNG6uxdql8SqrHzu6VH3Q=
 code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50/go.mod h1:GyubIUn2eHGSlpIqJhGKBKicAe6CUV/pQJosfNEHdo4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -106,6 +108,7 @@ github.com/hashicorp/memberlist v0.1.3 h1:EmmoJme1matNzb+hMpDuR/0sbJSUisxyqBGG67
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2 h1:YZ7UKsJv+hKjqGVUUbtE3HNj79Eln2oQ75tniF6iPt0=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -156,6 +159,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUt
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/square/certstrap v1.1.2-0.20181030173000-b612375892a7 h1:AUbF3PNK5UAg9tPJHqcRN7nRkrRK/mRWqkiqlQRN9Fk=
 github.com/square/certstrap v1.1.2-0.20181030173000-b612375892a7/go.mod h1:1+xoDwJbjCv1e3erNygZ/sHwgq8dr8CgQB3M5mMI6ds=
+github.com/square/certstrap v1.2.0/go.mod h1:CUHqV+fxJW0Y5UQFnnbYwQ7bpKXO1AKbic9g73799yw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
@@ -166,7 +170,9 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tedsuo/rata v1.0.0 h1:Sf9aZrYy6ElSTncjnGkyC2yuVvz5YJetBIUKJ4CmeKE=
 github.com/tedsuo/rata v1.0.0/go.mod h1:X47ELzhOoLbfFIY0Cql9P6yo3Cdwf2CMX3FVZxRzJPc=
+github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c h1:/nJuwDLoL/zrqY6gf57vxC+Pi+pZ8bfhpPkicO5H7W4=
@@ -203,6 +209,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/util/http.go
+++ b/util/http.go
@@ -1,10 +1,6 @@
 package util
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/tlsconfig"
@@ -14,43 +10,18 @@ type CertPaths struct {
 	Crt, Key, Ca string
 }
 
-func withSystemCertPool() tlsconfig.ClientOption {
-	return func(c *tls.Config) error {
-		caCertPool, err := x509.SystemCertPool()
-		if err != nil {
-			return fmt.Errorf("unable to load system cert pool: %v", err)
-		}
-		c.RootCAs = caCertPool
-		return nil
-	}
-}
-
-func withAdditionalAuthorityFromFile(caPath string) tlsconfig.ClientOption {
-	return func(c *tls.Config) error {
-		caBytes, err := ioutil.ReadFile(caPath)
-		if err != nil {
-			return fmt.Errorf("failed to read file %s: %s", caPath, err.Error())
-		}
-		if c.RootCAs == nil {
-			return fmt.Errorf("cannot add to empty cert pool")
-		}
-		if ok := c.RootCAs.AppendCertsFromPEM(caBytes); !ok {
-			return fmt.Errorf("unable to load CA certificate at %s", caPath)
-		}
-		return nil
-	}
-}
-
 func CreateTLSHTTPClient(certPaths []CertPaths) (*http.Client, error) {
 	tlsOpts := []tlsconfig.TLSOption{tlsconfig.WithInternalServiceDefaults()}
-	tlsClientOpts := []tlsconfig.ClientOption{withSystemCertPool()}
+	poolOpts := []tlsconfig.PoolOption{}
 
 	for _, certPath := range certPaths {
 		tlsOpts = append(tlsOpts, tlsconfig.WithIdentityFromFile(certPath.Crt, certPath.Key))
-		tlsClientOpts = append(tlsClientOpts, withAdditionalAuthorityFromFile(certPath.Ca))
+		poolOpts = append(poolOpts, tlsconfig.WithCertsFromFile(certPath.Ca))
 	}
 
-	tlsConfig, err := tlsconfig.Build(tlsOpts...).Client(tlsClientOpts...)
+	poolBuilder := tlsconfig.FromSystemPool(poolOpts...)
+	clientOption := tlsconfig.WithAuthorityBuilder(poolBuilder)
+	tlsConfig, err := tlsconfig.Build(tlsOpts...).Client(clientOption)
 	if err != nil {
 		return nil, err
 	}

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -30,15 +30,15 @@ var (
 var _ = Describe("HTTP", func() {
 	Context("CreateTLSHTTPClient", func() {
 		var (
-			systemCertSize int
-			testSubject1   []byte
-			testSubject2   []byte
+			systemCerts  [][]byte
+			testSubject1 []byte
+			testSubject2 []byte
 		)
 
 		BeforeEach(func() {
 			systemCertPool, err := x509.SystemCertPool()
 			Expect(err).NotTo(HaveOccurred())
-			systemCertSize = len(systemCertPool.Subjects())
+			systemCerts = systemCertPool.Subjects()
 			testSubject1 = extractSubject(path.Join(certPath, "1.cert"), path.Join(certPath, "1.key"))
 			testSubject2 = extractSubject(path.Join(certPath, "2.cert"), path.Join(certPath, "2.key"))
 		})
@@ -49,7 +49,9 @@ var _ = Describe("HTTP", func() {
 
 			config := client.Transport.(*http.Transport).TLSClientConfig
 			Expect(config.RootCAs).NotTo(BeNil())
-			Expect(config.RootCAs.Subjects()).To(HaveLen(systemCertSize))
+			for _, systemCert := range systemCerts {
+				Expect(config.RootCAs.Subjects()).To(ContainElement(systemCert))
+			}
 		})
 
 		It("Should append certificates", func() {
@@ -63,6 +65,7 @@ var _ = Describe("HTTP", func() {
 			Expect(config.RootCAs).NotTo(BeNil())
 			Expect(config.RootCAs.Subjects()).To(ContainElement(testSubject2))
 			Expect(config.RootCAs.Subjects()).To(ContainElement(testSubject1))
+			Expect(config.RootCAs.Subjects()).To(HaveLen(len(systemCerts) + 2))
 		})
 	})
 })

--- a/vendor/code.cloudfoundry.org/tlsconfig/authority.go
+++ b/vendor/code.cloudfoundry.org/tlsconfig/authority.go
@@ -1,0 +1,113 @@
+package tlsconfig
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+)
+
+// PoolOption is an functional option type that can be used to configure a
+// certificate pool.
+type PoolOption func(*x509.CertPool) error
+
+// PoolBuilder is used to build a certificate pool. You normally won't need to
+// Build this yourself and instead should use the WithAuthorityBuilder and
+// WithClientAuthenticationBuilder functions.
+type PoolBuilder struct {
+	base *x509.CertPool
+	opts []PoolOption
+	err  error
+}
+
+// Build creates the certificate pool.
+func (pb PoolBuilder) Build() (*x509.CertPool, error) {
+	if pb.err != nil {
+		return nil, pb.err
+	}
+
+	for _, opt := range pb.opts {
+		if err := opt(pb.base); err != nil {
+			return nil, err
+		}
+	}
+
+	return pb.base, nil
+}
+
+// FromEmptyPool creates a PoolBuilder from an empty certificate pool. The
+// options passed can amend the returned pool.
+func FromEmptyPool(opts ...PoolOption) PoolBuilder {
+	return PoolBuilder{
+		base: x509.NewCertPool(),
+		opts: opts,
+	}
+}
+
+// FromSystemPool creates a PoolBuilder from the system's certificate pool. The
+// options passed can amend the returned pool.
+func FromSystemPool(opts ...PoolOption) PoolBuilder {
+	pool, err := x509.SystemCertPool()
+	return PoolBuilder{
+		base: pool,
+		err:  err,
+		opts: opts,
+	}
+}
+
+// WithCertsFromFile will add all of the certificates found in a PEM-encoded
+// file to a certificate pool.
+func WithCertsFromFile(path string) PoolOption {
+	return func(pool *x509.CertPool) error {
+		pemCerts, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read certificate(s) at path %q: %s", path, err)
+		}
+
+		certsRead := 0
+		for len(pemCerts) > 0 {
+			var block *pem.Block
+			block, pemCerts = pem.Decode(pemCerts)
+			if block == nil {
+				break
+			}
+			if len(block.Headers) != 0 {
+				return fmt.Errorf("unexpected headers in PEM block in file %q: %v", path, block.Headers)
+			}
+			if block.Type != "CERTIFICATE" {
+				return fmt.Errorf("unexpected PEM block type %q in file %q", block.Type, path)
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return fmt.Errorf("failed to parse certificate in %q: %s", path, err)
+			}
+
+			if err := WithCert(cert)(pool); err != nil {
+				return fmt.Errorf("failed to add certificate in file %q to pool: %s", path, err)
+			}
+
+			certsRead++
+		}
+
+		if certsRead == 0 {
+			return fmt.Errorf("no valid certificates read from file %q", path)
+		}
+
+		return nil
+	}
+}
+
+// WithCert will add the certificate directly to a certificate pool.
+func WithCert(cert *x509.Certificate) PoolOption {
+	return func(pool *x509.CertPool) error {
+		// We do not check if the certificate is valid here in case that a user
+		// has an expired root certificate that they never use in their system
+		// certificate store.
+		//
+		// Perhaps we can only check the expiration in the case the that
+		// certificate is user specified?
+		pool.AddCert(cert)
+		return nil
+	}
+}

--- a/vendor/code.cloudfoundry.org/tlsconfig/go.mod
+++ b/vendor/code.cloudfoundry.org/tlsconfig/go.mod
@@ -1,3 +1,5 @@
 module code.cloudfoundry.org/tlsconfig
 
-require github.com/square/certstrap v1.1.2-0.20181030173000-b612375892a7
+require github.com/square/certstrap v1.2.0
+
+go 1.13

--- a/vendor/code.cloudfoundry.org/tlsconfig/go.sum
+++ b/vendor/code.cloudfoundry.org/tlsconfig/go.sum
@@ -1,2 +1,9 @@
-github.com/square/certstrap v1.1.2-0.20181030173000-b612375892a7 h1:AUbF3PNK5UAg9tPJHqcRN7nRkrRK/mRWqkiqlQRN9Fk=
-github.com/square/certstrap v1.1.2-0.20181030173000-b612375892a7/go.mod h1:1+xoDwJbjCv1e3erNygZ/sHwgq8dr8CgQB3M5mMI6ds=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
+github.com/square/certstrap v1.2.0 h1:ecgyABrbFLr8jSbOC6oTBmBek0t/HqtgrMUZCPuyfdw=
+github.com/square/certstrap v1.2.0/go.mod h1:CUHqV+fxJW0Y5UQFnnbYwQ7bpKXO1AKbic9g73799yw=
+github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
+golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/code.cloudfoundry.org/tlsconfig/verify.go
+++ b/vendor/code.cloudfoundry.org/tlsconfig/verify.go
@@ -2,15 +2,22 @@ package tlsconfig
 
 import (
 	"crypto/x509"
-	"errors"
+	"fmt"
 	"time"
 )
 
+const timeFormat = "2006-01-02 15:04:05 MST"
+
 func checkExpiration(cert *x509.Certificate) error {
-	sinceStart := time.Now().Sub(cert.NotBefore)
-	untilExpiry := cert.NotAfter.Sub(time.Now())
-	if untilExpiry < 0 || sinceStart < 0 {
-		return errors.New("the certificate has expired or is not yet valid")
+	now := time.Now()
+
+	if now.Before(cert.NotBefore) {
+		return fmt.Errorf("certificate is not yet valid: validity starts at %s but current time is %s", cert.NotBefore.Format(timeFormat), now.Format(timeFormat))
 	}
+
+	if now.After(cert.NotAfter) {
+		return fmt.Errorf("certificate has expired: validity ended at %s but current time is %s", cert.NotAfter.Format(timeFormat), now.Format(timeFormat))
+	}
+
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ code.cloudfoundry.org/bbs/models
 code.cloudfoundry.org/lager
 # code.cloudfoundry.org/runtimeschema v0.0.0-20180622184205-c38d8be9f68c
 code.cloudfoundry.org/runtimeschema/cc_messages
-# code.cloudfoundry.org/tlsconfig v0.0.0-20190710180242-462f72de1106
+# code.cloudfoundry.org/tlsconfig v0.0.0-20200108215323-551ec42d1f74
 code.cloudfoundry.org/tlsconfig
 # code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50
 code.cloudfoundry.org/urljoiner


### PR DESCRIPTION
* Uses new functions from the `tlsconfig`-library to configure server-side authentication.
* Removes our temporary helper functions.